### PR TITLE
Add visual drop target indicators for drag and drop

### DIFF
--- a/components/DragDropContext.tsx
+++ b/components/DragDropContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext } from 'react';
+import { useSharedValue } from 'react-native-reanimated';
+
+interface DragDropContextValue {
+  isDragging: ReturnType<typeof useSharedValue<boolean>>;
+  draggedIndex: ReturnType<typeof useSharedValue<number>>;
+  dropTargetIndex: ReturnType<typeof useSharedValue<number>>;
+}
+
+const DragDropContext = createContext<DragDropContextValue | null>(null);
+
+export const DragDropProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const isDragging = useSharedValue(false);
+  const draggedIndex = useSharedValue(-1);
+  const dropTargetIndex = useSharedValue(-1);
+
+  return (
+    <DragDropContext.Provider value={{ isDragging, draggedIndex, dropTargetIndex }}>
+      {children}
+    </DragDropContext.Provider>
+  );
+};
+
+export const useDragDrop = () => {
+  const context = useContext(DragDropContext);
+  if (!context) {
+    throw new Error('useDragDrop must be used within DragDropProvider');
+  }
+  return context;
+};

--- a/components/DraggableTaskCard.tsx
+++ b/components/DraggableTaskCard.tsx
@@ -6,6 +6,7 @@ import * as Haptics from 'expo-haptics';
 import { useTaskStore } from '../store/taskStore';
 import { Task } from '../types/Task';
 import { SwipeableTaskCard } from './SwipeableTaskCard';
+import { useDragDrop } from './DragDropContext';
 
 // Constants
 const TASK_CARD_HEIGHT = 80; // Approximate height of a task card
@@ -22,69 +23,82 @@ export const DraggableTaskCard: React.FC<DraggableTaskCardProps> = ({
   isDragEnabled = true 
 }) => {
   const { reorderTasks, getActiveTasks } = useTaskStore();
+  const { isDragging: globalIsDragging, draggedIndex, dropTargetIndex } = useDragDrop();
 
   const translateY = useSharedValue(0);
   const scale = useSharedValue(1);
   const zIndex = useSharedValue(0);
-  const isDragging = useSharedValue(false);
 
   const handleDragStart = useCallback(() => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
   }, []);
 
-  const handleDragEnd = useCallback((fromIndex: number, toIndex: number) => {
-    if (fromIndex !== toIndex) {
-      reorderTasks(fromIndex, toIndex);
+  const handleDragEnd = useCallback((fromIndex: number, toIndex: number, displacement: number) => {
+    const activeTasks = getActiveTasks();
+    const maxIndex = Math.max(0, activeTasks.length - 1);
+    const calculatedToIndex = Math.max(0, Math.min(
+      Math.round(fromIndex + displacement / TASK_CARD_HEIGHT),
+      maxIndex
+    ));
+    
+    if (fromIndex !== calculatedToIndex) {
+      reorderTasks(fromIndex, calculatedToIndex);
     }
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-  }, [reorderTasks]);
+  }, [reorderTasks, getActiveTasks]);
 
   const longPressGesture = Gesture.LongPress()
     .minDuration(500)
     .onStart(() => {
       runOnJS(handleDragStart)();
-      isDragging.value = true;
+      globalIsDragging.value = true;
+      draggedIndex.value = index;
       scale.value = withSpring(1.05);
       zIndex.value = 1000;
     });
 
   const panGesture = Gesture.Pan()
     .onUpdate((event) => {
-      if (isDragging.value) {
+      if (globalIsDragging.value && draggedIndex.value === index) {
         translateY.value = event.translationY;
+        
+        // Calculate potential drop target index
+        const displacement = event.translationY;
+        const potentialIndex = Math.round(index + displacement / TASK_CARD_HEIGHT);
+        dropTargetIndex.value = Math.max(0, potentialIndex);
       }
     })
     .onEnd((event) => {
-      if (isDragging.value) {
+      if (globalIsDragging.value && draggedIndex.value === index) {
         const displacement = event.translationY;
-        const activeTasks = getActiveTasks();
-        const maxIndex = Math.max(0, activeTasks.length - 1);
-        const newIndex = Math.max(0, Math.min(
-          Math.round(index + displacement / TASK_CARD_HEIGHT),
-          maxIndex
-        ));
         
-        runOnJS(handleDragEnd)(index, newIndex);
+        runOnJS(handleDragEnd)(index, index, displacement);
         
         // Reset values
-        isDragging.value = false;
+        globalIsDragging.value = false;
+        draggedIndex.value = -1;
         translateY.value = withSpring(0);
         scale.value = withSpring(1);
         zIndex.value = 0;
+        dropTargetIndex.value = -1;
       }
     });
 
   const composedGesture = Gesture.Simultaneous(longPressGesture, panGesture);
 
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [
-      { translateY: translateY.value },
-      { scale: scale.value },
-    ],
-    zIndex: zIndex.value,
-    elevation: isDragging.value ? 10 : 2,
-    opacity: isDragging.value ? 0.9 : 1,
-  }));
+  const animatedStyle = useAnimatedStyle(() => {
+    const isBeingDragged = globalIsDragging.value && draggedIndex.value === index;
+    
+    return {
+      transform: [
+        { translateY: translateY.value },
+        { scale: scale.value },
+      ],
+      zIndex: zIndex.value,
+      elevation: isBeingDragged ? 10 : 2,
+      opacity: isBeingDragged ? 0.9 : 1,
+    };
+  });
 
   if (!isDragEnabled) {
     return <SwipeableTaskCard task={task} index={index} />;

--- a/components/DropZone.tsx
+++ b/components/DropZone.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
+import { useDragDrop } from './DragDropContext';
+
+interface DropZoneProps {
+  index: number;
+}
+
+export const DropZone: React.FC<DropZoneProps> = ({ index }) => {
+  const { isDragging, dropTargetIndex, draggedIndex } = useDragDrop();
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const isTargetZone = dropTargetIndex.value === index && 
+                         isDragging.value && 
+                         draggedIndex.value !== index;
+    
+    return {
+      height: isTargetZone ? 40 : 4,
+      opacity: isTargetZone ? 1 : 0,
+      backgroundColor: isTargetZone ? '#E5E5E7' : 'transparent',
+    };
+  });
+
+  return <Animated.View style={[styles.dropZone, animatedStyle]} />;
+};
+
+const styles = StyleSheet.create({
+  dropZone: {
+    marginVertical: 2,
+    borderRadius: 20,
+    marginHorizontal: 16,
+  },
+});

--- a/components/TaskList.tsx
+++ b/components/TaskList.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { FlatList, StyleSheet, Text, View } from 'react-native';
 import { Task } from '../types/Task';
 import { DraggableTaskCard } from './DraggableTaskCard';
+import { DragDropProvider } from './DragDropContext';
+import { DropZone } from './DropZone';
 
 interface TaskListProps {
   tasks: Task[];
@@ -18,20 +20,26 @@ export function TaskList({ tasks }: TaskListProps) {
   }
 
   return (
-    <FlatList
-      data={tasks}
-      keyExtractor={(item) => item.id}
-      renderItem={({ item, index }) => (
-        <DraggableTaskCard 
-          task={item} 
-          index={index} 
-          isDragEnabled={true}
-        />
-      )}
-      showsVerticalScrollIndicator={false}
-      contentContainerStyle={styles.listContainer}
-      scrollEnabled={true}
-    />
+    <DragDropProvider>
+      <FlatList
+        data={tasks}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item, index }) => (
+          <>
+            <DropZone index={index} />
+            <DraggableTaskCard 
+              task={item} 
+              index={index} 
+              isDragEnabled={true}
+            />
+            {index === tasks.length - 1 && <DropZone index={index + 1} />}
+          </>
+        )}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.listContainer}
+        scrollEnabled={true}
+      />
+    </DragDropProvider>
   );
 }
 

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,4 +1,6 @@
 export { DraggableTaskCard } from './DraggableTaskCard';
+export { DragDropProvider, useDragDrop } from './DragDropContext';
+export { DropZone } from './DropZone';
 export { FAB } from './FAB';
 export { InlineTextEdit } from './InlineTextEdit';
 export { LocationPicker } from './LocationPicker';


### PR DESCRIPTION
## Summary
- Adds visual drop zone indicators during drag and drop operations
- Fixes Reanimated worklet error that was preventing drag functionality
- Implements subtle gray drop zones that appear between tasks during drag

## Key Changes
- **DragDropContext**: Shared context for global drag state across components
- **DropZone component**: Animated visual feedback showing where tasks will be dropped
- **Fixed worklet error**: Moved `getActiveTasks()` call from UI thread to JS thread
- **Improved UX**: Drop zones only appear at valid drop locations (not starting position)
- **Design refinement**: Uses subtle gray color (`#E5E5E7`) for better visual hierarchy

## Test plan
- [x] Long press a task to initiate drag
- [x] Verify drop zones appear between other tasks (but not at starting position)
- [x] Verify drop zones are subtle gray color
- [x] Confirm drag and drop reordering works without Reanimated errors
- [x] Test that animations are smooth and responsive

🤖 Generated with [Claude Code](https://claude.ai/code)