### PR TITLE
Remove isScheduled flag and related UI from tasks

### DIFF
--- a/components/TaskCard.tsx
+++ b/components/TaskCard.tsx
@@ -209,19 +209,6 @@ export function TaskCard({ task }: TaskCardProps) {
             {formatDate(task.createdAt)}
           </Text>
 
-          {/* Schedule Indicator */}
-          {task.isScheduled && (
-            <View style={styles.scheduleIndicator}>
-              <Ionicons
-                name="repeat"
-                size={14}
-                color="#28a745"
-                style={styles.scheduleIcon}
-              />
-              <Text style={styles.scheduleText}>Scheduled</Text>
-            </View>
-          )}
-
           {/* Future Task Indicator */}
           {task.isFutureTask && (
             <View style={styles.scheduleIndicator}>

--- a/store/taskStore.ts
+++ b/store/taskStore.ts
@@ -153,7 +153,6 @@ export const useTaskStore = create<TaskStore>((set, get) => ({
       id: Date.now().toString() + Math.random().toString(36).substr(2, 9),
       createdAt: new Date(),
       order: Date.now(), // New tasks appear at top
-      isScheduled: !!taskData.schedule,
       isFutureTask: !!taskData.isFutureTask,
     }
 
@@ -294,7 +293,6 @@ export const useTaskStore = create<TaskStore>((set, get) => ({
                 endDate: parseDateField(task.schedule.endDate),
               }
             : undefined,
-          isScheduled: task.isScheduled || false,
           isFutureTask: task.isFutureTask || false,
           seriesId: task.seriesId || undefined,
         }))
@@ -398,7 +396,6 @@ export const useTaskStore = create<TaskStore>((set, get) => ({
           ? {
               ...t,
               schedule,
-              isScheduled: !!schedule,
               seriesId: schedule ? seriesId : undefined,
             }
           : t,

--- a/types/Task.ts
+++ b/types/Task.ts
@@ -30,7 +30,6 @@ export interface Task {
   imageUri?: string // For tasks created from camera
   // Schedule fields
   schedule?: Schedule // For recurring tasks
-  isScheduled?: boolean // Flag to identify scheduled tasks
   isFutureTask?: boolean // Flag to identify future tasks generated from schedules
   seriesId?: string // Identifier for tasks that belong to the same recurring series
 }


### PR DESCRIPTION
## Summary
- Removed the `isScheduled` flag from the `Task` type and task store
- Eliminated all references to `isScheduled` in the task creation, update, and retrieval logic
- Removed the scheduled task indicator UI from the `TaskCard` component

## Changes

### Type System
- Deleted the `isScheduled` optional boolean from the `Task` interface

### Task Store
- Removed setting and updating of `isScheduled` in task creation and update flows

### UI Components
- Removed the scheduled status indicator (icon and label) from the `TaskCard` component

## Rationale
- The `isScheduled` flag and its UI representation were redundant or deprecated
- Simplifies task model and UI by focusing on `isFutureTask` for schedule-related task states

## Test plan
- Verified no scheduled indicator appears on task cards
- Confirmed no errors or warnings related to `isScheduled` in task store operations
- Tested task creation and updates to ensure schedule-related functionality remains intact without `isScheduled`

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/677b7671-c8d5-4a7f-9f42-fc5f6c129de6