### PR TITLE
Refactor backend tests with unified pytest markers and update test scripts

### DIFF
--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,6 +1,7 @@
 import pytest
 from httpx import AsyncClient
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_health_check(client: AsyncClient):
     """

--- a/backend/tests/test_integration_example.py
+++ b/backend/tests/test_integration_example.py
@@ -6,6 +6,9 @@ Run with: pytest tests/test_integration_example.py -s
 import pytest
 from httpx import AsyncClient
 
+# Mark all tests in this file as integration tests
+pytestmark = pytest.mark.integration
+
 @pytest.mark.asyncio
 async def test_full_todo_lifecycle(client: AsyncClient, setup_test_user):
     """Test creating, reading, updating, and deleting a todo."""

--- a/backend/tests/test_todos.py
+++ b/backend/tests/test_todos.py
@@ -4,6 +4,9 @@ from faker import Faker
 
 fake = Faker()
 
+# Mark all tests in this file as integration tests
+pytestmark = pytest.mark.integration
+
 @pytest.mark.asyncio
 async def test_create_task(client: AsyncClient, setup_test_user):
     """Test creating a new task."""

--- a/backend/tests/test_todos_unit.py
+++ b/backend/tests/test_todos_unit.py
@@ -4,6 +4,7 @@ from unittest.mock import patch, MagicMock
 import uuid
 from datetime import datetime
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_create_task_unit(client: AsyncClient):
     """Unit test for creating a task - mocks database calls."""
@@ -55,6 +56,7 @@ async def test_create_task_unit(client: AsyncClient):
         mock_supabase.table.assert_called_with('tasks')
         mock_table.insert.assert_called_once()
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_get_tasks_unit(client: AsyncClient):
     """Unit test for getting tasks - mocks database calls."""
@@ -109,6 +111,7 @@ async def test_get_tasks_unit(client: AsyncClient):
         assert len(tasks) == 2
         assert tasks[0]["title"] == "Task 1"
 
+@pytest.mark.unit
 @pytest.mark.asyncio  
 async def test_delete_task_not_found(client: AsyncClient):
     """Test deleting non-existent task returns 404."""

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "dev:backend": "cd backend && uv run uvicorn app.main:app --reload --port 8000",
     "install:all": "pnpm install && cd backend && uv sync",
     "test:backend": "cd backend && pytest",
-    "test:backend:unit": "cd backend && pytest tests/test_*_unit.py -v",
-    "test:backend:integration": "cd backend && pytest tests/test_*_integration.py -v -m integration",
+    "test:backend:unit": "cd backend && pytest -m unit -v",
+    "test:backend:integration": "cd backend && pytest -m integration -v",
     "test:backend:watch": "cd backend && pytest-watch",
     "prepare": "husky"
   },
@@ -23,7 +23,7 @@
     "backend/**/*.py": [
       "cd backend && uv run ruff check --fix",
       "cd backend && uv run mypy",
-      "cd backend && uv run pytest tests/test_*_unit.py -v"
+      "cd backend && uv run pytest -m unit -v"
     ]
   },
   "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad"


### PR DESCRIPTION
## Summary
- Added consistent pytest markers (`unit` and `integration`) to backend test files
- Updated `package.json` test scripts to use pytest markers for unit and integration tests

## Changes

### Backend Tests
- Marked `test_health.py` tests with `@pytest.mark.unit`
- Added `pytestmark = pytest.mark.integration` to `test_integration_example.py` and `test_todos.py` to mark all tests in these files as integration tests
- Added `@pytest.mark.unit` to individual tests in `test_todos_unit.py` for clear unit test identification

### Package Scripts
- Modified `test:backend:unit` script to run `pytest -m unit -v` instead of targeting specific test file patterns
- Modified `test:backend:integration` script to run `pytest -m integration -v` for integration tests
- Updated lint-staged configuration to run unit tests using the new marker-based command

## Test plan
- Run `pnpm run test:backend:unit` to verify only unit tests run
- Run `pnpm run test:backend:integration` to verify only integration tests run
- Confirm all tests pass with the new marker setup
- Validate lint-staged hooks trigger unit tests correctly

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/844c597f-310b-46f5-80b4-7b6799d4e176