### PR TITLE
Add Terragon setup script

### DIFF
--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# terragon-setup.sh - Custom setup script for your Terragon environment
+# This script runs when your sandbox environment starts
+
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Add UV to PATH - UV installs to ~/.local/bin, not ~/.cargo
+export PATH="$HOME/.local/bin:$PATH"
+
+# Install pnpm globally
+npm install -g pnpm
+
+# Try to approve builds (though it seems there's nothing to approve)
+pnpm approve-builds supabase || true
+
+# Install dependencies
+pnpm run install:all
+
+echo "Setup complete!"


### PR DESCRIPTION
## Summary

Adds the `terragon-setup.sh` script that runs when Terragon sandboxes are created for this repository.

## Changes

- Created `terragon-setup.sh` with custom setup commands

## Test plan

The setup script has been tested in a Terragon sandbox and runs successfully.

---
Created via [Terragon](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback