### PR TITLE
Link title to home/do-next tab

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -4,7 +4,12 @@ import Link from "next/link";
 export function Header() {
 	return (
 		<div className="flex justify-between items-center mb-6">
-			<h1 className="text-3xl font-bold text-gray-800">todo.house</h1>
+			<Link
+				href="/"
+				className="text-3xl font-bold text-gray-800 hover:text-gray-900 transition-colors"
+			>
+				todo.house
+			</Link>
 			<Link href="/settings" className="p-2 text-gray-600 hover:text-gray-900">
 				<SettingsIcon size={20} />
 			</Link>

--- a/frontend/src/components/__tests__/Header.test.tsx
+++ b/frontend/src/components/__tests__/Header.test.tsx
@@ -2,35 +2,35 @@ import { render, screen } from "@testing-library/react";
 import { Header } from "../Header";
 
 describe("Header", () => {
-	it("renders the app title", () => {
+	it("renders the app title as a link to home", () => {
 		render(<Header />);
 
-		expect(screen.getByText("todo.house")).toBeInTheDocument();
+		const titleLink = screen.getByRole("link", { name: "todo.house" });
+		expect(titleLink).toBeInTheDocument();
+		expect(titleLink).toHaveAttribute("href", "/");
+		expect(titleLink).toHaveClass(
+			"text-3xl",
+			"font-bold",
+			"text-gray-800",
+			"hover:text-gray-900",
+			"transition-colors",
+		);
 	});
 
 	it("renders the settings link", () => {
 		render(<Header />);
 
-		const settingsLink = screen.getByRole("link");
+		const settingsLink = screen.getByRole("link", { name: "" });
 		expect(settingsLink).toBeInTheDocument();
 		expect(settingsLink).toHaveAttribute("href", "/settings");
-	});
-
-	it("has correct styling", () => {
-		render(<Header />);
-
-		const title = screen.getByText("todo.house");
-		expect(title).toHaveClass("text-3xl", "font-bold", "text-gray-800");
-
-		const settingsLink = screen.getByRole("link");
 		expect(settingsLink).toHaveClass("text-gray-600", "hover:text-gray-900");
 	});
 
 	it("renders settings icon", () => {
 		render(<Header />);
 
-		// The icon is rendered as an SVG within the link
-		const settingsLink = screen.getByRole("link");
+		// The icon is rendered as an SVG within the settings link
+		const settingsLink = screen.getByRole("link", { name: "" });
 		const svg = settingsLink.querySelector("svg");
 		expect(svg).toBeInTheDocument();
 	});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The header title "todo.house" is now a clickable link that navigates to the home page, with improved hover effects and color transitions for better interactivity.

* **Tests**
  * Updated header component tests to verify the title's link behavior, accessibility, and styling. Improved test clarity and consistency for the settings link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->