### PR TITLE
Fix: Keep tabs visible during task loading

### DIFF
--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -109,26 +109,6 @@ export function TaskList() {
 		setActiveTab(newTab);
 	}, [pathname]);
 
-	if (loading) {
-		return (
-			<div className="flex justify-center items-center py-12">
-				<div
-					className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500"
-					data-testid="loading-spinner"
-				></div>
-			</div>
-		);
-	}
-
-	if (error) {
-		return (
-			<div className="text-center py-8">
-				<p className="text-red-500 mb-2">Failed to load tasks</p>
-				<p className="text-sm text-gray-500">{error}</p>
-			</div>
-		);
-	}
-
 	// Map backend tasks to UI format
 	const uiTasks = localTasks.map(mapTaskToUI);
 	const filteredTasks = uiTasks.filter(
@@ -179,21 +159,37 @@ export function TaskList() {
 			</div>
 
 			<div className="space-y-4">
-				<AnimatePresence mode="popLayout">
-					{filteredTasks.map((task) => (
-						<TaskItem
-							key={task.id}
-							task={task}
-							onTaskUpdate={() => handleTaskRemoval(task.id)}
-							activeTab={activeTab}
-						/>
-					))}
-				</AnimatePresence>
-
-				{filteredTasks.length === 0 && (
-					<div className="text-center py-8">
-						<p className="text-gray-500">No tasks in this category</p>
+				{loading ? (
+					<div className="flex justify-center items-center py-12">
+						<div
+							className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500"
+							data-testid="loading-spinner"
+						></div>
 					</div>
+				) : error ? (
+					<div className="text-center py-8">
+						<p className="text-red-500 mb-2">Failed to load tasks</p>
+						<p className="text-sm text-gray-500">{error}</p>
+					</div>
+				) : (
+					<>
+						<AnimatePresence mode="popLayout">
+							{filteredTasks.map((task) => (
+								<TaskItem
+									key={task.id}
+									task={task}
+									onTaskUpdate={() => handleTaskRemoval(task.id)}
+									activeTab={activeTab}
+								/>
+							))}
+						</AnimatePresence>
+
+						{filteredTasks.length === 0 && (
+							<div className="text-center py-8">
+								<p className="text-gray-500">No tasks in this category</p>
+							</div>
+						)}
+					</>
 				)}
 
 				<hr className="my-4 border-gray-200" />


### PR DESCRIPTION
## Summary
- Tabs now remain visible when loading tasks
- Only the task content shows loading spinner

🤖 Generated with [Claude Code](https://claude.ai/code)